### PR TITLE
Fix Code function for grpc errors

### DIFF
--- a/status.go
+++ b/status.go
@@ -207,8 +207,8 @@ func Code(err error) codes.Code {
 	if err == nil {
 		return codes.OK
 	}
-	if se, ok := err.(interface{ Status() *status.Status }); ok {
-		return se.Status().Code()
+	if se, ok := err.(interface{ GRPCStatus() *status.Status }); ok {
+		return se.GRPCStatus().Code()
 	}
 	return codes.Unknown
 }

--- a/status_test.go
+++ b/status_test.go
@@ -218,6 +218,37 @@ func TestConvertUnknownError(t *testing.T) {
 	}
 }
 
+func TestCode(t *testing.T) {
+	tests := []struct {
+		err error
+		code codes.Code
+	}{
+		{
+			err: nil,
+			code: codes.OK,
+		},
+		{
+			err: errors.New("unknown error"),
+			code: codes.Unknown,
+		},
+		{
+			err: Errorf(codes.Internal, "internal error"),
+			code: codes.Internal,
+		},
+		{
+			err: Errorf(codes.Unknown, "explicitly unknown error"),
+			code: codes.Unknown,
+		},
+	}
+
+	for _, tc := range tests {
+		code := Code(tc.err)
+		if code != tc.code {
+			t.Fatalf("Code(%v) = %v; want %v", tc.err, code, tc.code)
+		}
+	}
+}
+
 func TestStatus_ErrorDetails(t *testing.T) {
 	tests := []struct {
 		code    codes.Code


### PR DESCRIPTION
`Status` was renamed to `GRPCStatus` everywhere except `Code` function